### PR TITLE
Add junit output option and test_passfail example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ How to run
 ####Note:
      * Automation test logs are at /var/log/tests/ by default in management node. This can be changed by exporting LOG_FILE="/new/path/"
 
+ - To create junit output in directory /tmp/test_results: `python main.py -j /tmp/test_results`
 
 How to write tests
 ====================

--- a/distaf/main.py
+++ b/distaf/main.py
@@ -5,8 +5,10 @@ import re
 import sys
 import unittest
 import argparse
+import xmlrunner
+from distaf.util import testcases, finii
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 if os.getcwd() not in sys.path:
     sys.path.append(os.getcwd())
@@ -59,11 +61,12 @@ def set_tests(tests=[]):
 
 
 def main():
-    from distaf.util import testcases, finii
-
     parser = argparse.ArgumentParser()
     parser.add_argument("-t", help="Test case(s) to run")
     parser.add_argument("-d", help="Directory to choose tests from")
+    parser.add_argument("-j", help="Directory to store JUnit XML file",
+                        action="store",
+                        dest="xmldir")
     args = parser.parse_args()
 
     if args.d != None and args.t != None:
@@ -82,7 +85,12 @@ def main():
     get_num = lambda x: int(re.search(r'test_([0-9]+)_', x).group(1))
     sortcmp = lambda _, x, y: cmp(get_num(x), get_num(y))
     unittest.TestLoader.sortTestMethodsUsing = sortcmp
-    runner = unittest.TextTestRunner(verbosity=2)
+
+    if args.xmldir != None:
+        runner = xmlrunner.XMLTestRunner(output=args.xmldir)
+    else:
+        runner = unittest.TextTestRunner(verbosity=2)
+
     itersuite = unittest.TestLoader().loadTestsFromTestCase(gluster_tests)
     runner.run(itersuite)
     finii()

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Programming Language :: Python :: 2.7'
         'Topic :: Software Development :: Testing'
     ],
-    install_requires=['plumbum', 'rpyc'],
+    install_requires=['plumbum', 'rpyc', 'unittest-xml-reporting'],
     entry_points={
         'console_scripts': [
             'distaf = distaf.main:main',

--- a/tests_d/example/test_passfail.py
+++ b/tests_d/example/test_passfail.py
@@ -1,0 +1,27 @@
+from distaf.util import tc, testcase
+
+@testcase("this_should_pass")
+def get_hostname():
+    tc.logger.info("Testing connection and command exec")
+    mnode = tc.nodes[0]
+    ret, _, _ = tc.run(mnode, "hostname")
+
+    if ret != 0:
+        tc.logger.error("hostname command failed")
+
+        return False
+    else:
+        return True
+
+@testcase("this_should_fail")
+def going_to_fail():
+    tc.logger.info("Testing fail output")
+    mnode = tc.nodes[0]
+    ret, _, _ = tc.run(mnode, "false")
+
+    if ret != 0:
+        tc.logger.error("false command failed")
+
+        return False
+    else:
+        return True


### PR DESCRIPTION
- Added -j XMLDIR option to create junit XML
- Added unittest-xml-reporting to setup.py install_requires
- Moved distaf.util import to top of file
- Added example/test_passfail.py for basic setup and reporting test

Signed-off-by: Jonathan Holloway <loadtheaccumulator@gmail.com>