### PR TITLE
Add straight ssh for remote shell commands and examples to test

### DIFF
--- a/distaf/client_rpyc.py
+++ b/distaf/client_rpyc.py
@@ -19,6 +19,7 @@
 import os
 import time
 import logging
+
 from plumbum import SshMachine
 from rpyc.utils.zerodeploy import DeployedServer
 
@@ -51,22 +52,37 @@ class BigBang():
         self.logger = logging.getLogger('distaf')
         self.lhndlr = logging.FileHandler(client_logfile)
         formatter = logging.Formatter('%(asctime)s %(levelname)s %(funcName)s '
-                                     '%(message)s')
+                                      '%(message)s')
         self.lhndlr.setFormatter(formatter)
         self.logger.addHandler(self.lhndlr)
         self.logger.setLevel(loglevel)
+        self.skip_log_inject = self.global_config.get('skip_log_inject', False)
 
-        # Make connections
+        # connection store for _get_ssh()
+        self.use_ssh = self.global_config.get('use_ssh', False)
+        self.use_controlpersist = \
+            self.global_config.get('use_controlpersist', False)
+
+        if self.use_ssh:
+            # using separate ssh connections at the moment
+            # ssh connections are requested on-the-fly via run()
+            self.sshconns = {}
+
+        # rpyc connection handles (still needed for on-the-fly connections
         self.connection_handles = {}
         self.subp_conn = {}
-        for node in self.all_nodes:
-            self.logger.debug("Connecting to node: %s" % node)
-            ret = self.establish_connection(node, self.user)
-            if not ret:
-                self.logger.warning("Unable to establish connection with: %s" \
-                        % node)
-            else:
-                self.logger.debug("Connected to node: %s" % node)
+        # skipping the rpyc connections until requested to speed startup time
+        # if zerodeploy delay interferes with a testcase, user can "prime" the
+        #    connection by calling establish_connection in the testcase.setup
+        if not self.use_ssh:
+            for node in self.all_nodes:
+                self.logger.debug("Connecting to node: %s" % node)
+                ret = self.establish_connection(node, self.user)
+                if not ret:
+                    self.logger.warning("Unable to establish connection "
+                                        "with: %s" % node)
+                else:
+                    self.logger.debug("Connected to node: %s" % node)
 
     def establish_connection(self, node, user):
         """
@@ -121,8 +137,44 @@ class BigBang():
             self.logger.critical("Unable to connect to %s" % node)
             return False
         else:
-            self.logger.debug("Connection re-established to %s" % node)
+            self.logger.debug("Connection (re-)established to %s" % node)
             return True
+
+    def _get_ssh(self, node, user):
+        """Setup a SshMachine connection for non-rpyc connections"""
+        ssh_opts = ()
+        ssh_opts += ('-T',
+                     '-oPasswordAuthentication=no',
+                     '-oStrictHostKeyChecking=no',
+                     '-oPort=22',
+                     '-oConnectTimeout=10')
+
+        keyfile = None
+        if 'ssh_keyfile' in self.global_config:
+            keyfile = self.global_config['ssh_keyfile']
+            ssh_opts += ('-o', 'IdentityFile=%s' % keyfile)
+
+        if self.use_controlpersist:
+            ssh_opts += ('-oControlMaster=auto',
+                         '-oControlPersist=30m',
+                         '-oControlPath=~/.ssh/distaf-ssh-%r@%h:%p')
+
+        ssh_opts_str = " ".join(ssh_opts)
+
+        conn_name = "%s@%s" % (user, node)
+        # if no existing connection, create one
+        if conn_name not in self.sshconns:
+            # we already have plumbum imported for rpyc, so let's use it
+            ssh = SshMachine(node, user, ssh_opts=ssh_opts)
+            self.sshconns[conn_name] = ssh
+        else:
+            ssh = self.sshconns[conn_name]
+
+        if ssh:
+            return ssh
+
+        self.logger.error("oops. did not get ssh for %s", conn_name)
+        return None
 
     def run(self, node, cmd, user='', verbose=True):
         """
@@ -134,27 +186,63 @@ class BigBang():
         if user == '':
             user = self.user
         self.logger.info("Executing %s on %s" % (cmd, node))
-        try:
-            subp = self.subp_conn[node][user]
-            p = subp.Popen(cmd, shell=True, stdout=subp.PIPE, stderr=subp.PIPE)
-        except:
-            ret = self.refresh_connection(node, user)
-            if not ret:
-                self.logger.critical("Unable to connect to %s@%s" \
-                        % (user, node))
-                return (-1, -1, -1)
-            subp = self.subp_conn[node][user]
-            p = subp.Popen(cmd, shell=True, stdout=subp.PIPE, stderr=subp.PIPE)
-        pout, perr = p.communicate()
-        ret = p.returncode
-        self.logger.info("\"%s\" on %s: RETCODE is %d" % (cmd, node, ret))
-        if pout != "" and verbose:
-            self.logger.info("\"%s\" on %s: STDOUT is \n %s" % \
-                            (cmd, node, pout))
-        if perr != "" and verbose:
-            self.logger.error("\"%s\" on %s: STDERR is \n %s" % \
-                            (cmd, node, perr))
-        return (ret, pout, perr)
+
+        if self.use_ssh:
+            """
+            Use straight ssh for all run shell command connections,
+                and only create rpyc connections as needed.
+            Setting global config vars enables SSH and/or CONTROLPERSIST.
+                use_ssh : True
+                use_controlpersist : True
+
+            Depending on test, can cut runtime by 1/2 to 2/3 compared to using
+                the rpyc connection for all remote calls.
+            NOTE: using ssh without control persist can take longer than rpyc
+            """
+            ctlpersist = ''
+            if self.use_controlpersist:
+                ctlpersist = " (cp)"
+
+            # output command
+            self.logger.debug("%s@%s%s: %s", user, node, ctlpersist, cmd)
+            # run the command
+            ssh = self._get_ssh(node, user)
+            p = ssh.popen(cmd)
+            pout, perr = p.communicate(input=cmd)
+            prcode = p.returncode
+
+            # output command results
+            self.logger.info("RETCODE: %s" % prcode)
+            if pout != "" and verbose:
+                self.logger.info("STDOUT:\n%s" % pout)
+            if perr != "" and verbose:
+                self.logger.error("STDERR:\n%s" % perr)
+
+            return (prcode, pout, perr)
+        else:
+            try:
+                subp = self.subp_conn[node][user]
+                p = subp.Popen(cmd, shell=True,
+                               stdout=subp.PIPE, stderr=subp.PIPE)
+            except:
+                ret = self.refresh_connection(node, user)
+                if not ret:
+                    self.logger.critical("Unable to connect to %s@%s" %
+                                         (user, node))
+                    return (-1, -1, -1)
+                subp = self.subp_conn[node][user]
+                p = subp.Popen(cmd, shell=True,
+                               stdout=subp.PIPE, stderr=subp.PIPE)
+            pout, perr = p.communicate()
+            ret = p.returncode
+            self.logger.info("\"%s\" on %s: RETCODE is %d" % (cmd, node, ret))
+            if pout != "" and verbose:
+                self.logger.info("\"%s\" on %s: STDOUT is \n %s" %
+                                 (cmd, node, pout))
+            if perr != "" and verbose:
+                self.logger.error("\"%s\" on %s: STDERR is \n %s" %
+                                  (cmd, node, perr))
+            return (ret, pout, perr)
 
     def run_async(self, node, cmd, user='', verbose=True):
         """
@@ -162,6 +250,7 @@ class BigBang():
         """
         if user == '':
             user = self.user
+
         try:
             c = self.connection_handles[node][user][1].classic_connect()
         except:
@@ -171,8 +260,9 @@ class BigBang():
                 return None
             c = self.connection_handles[node][user][1].classic_connect()
         self.logger.info("Executing %s on %s asynchronously" % (cmd, node))
-        p = c.modules.subprocess.Popen(cmd, shell=True, \
-            stdout=c.modules.subprocess.PIPE, stderr=c.modules.subprocess.PIPE)
+        p = c.modules.subprocess.Popen(cmd, shell=True,
+                                       stdout=c.modules.subprocess.PIPE,
+                                       stderr=c.modules.subprocess.PIPE)
 
         def value():
             """
@@ -181,14 +271,14 @@ class BigBang():
             pout, perr = p.communicate()
             retc = p.returncode
             c.close()
-            self.logger.info("\"%s\" on \"%s\": RETCODE is %d" % \
-            (cmd, node, retc))
+            self.logger.info("\"%s\" on \"%s\": RETCODE is %d" %
+                             (cmd, node, retc))
             if pout != "" and verbose:
-                self.logger.debug("\"%s\" on \"%s\": STDOUT is \n %s" % \
-                (cmd, node, pout))
+                self.logger.debug("\"%s\" on \"%s\": STDOUT is \n %s" %
+                                  (cmd, node, pout))
             if perr != "" and verbose:
-                self.logger.error("\"%s\" on \"%s\": STDERR is \n %s" % \
-                (cmd, node, perr))
+                self.logger.error("\"%s\" on \"%s\": STDERR is \n %s" %
+                                  (cmd, node, perr))
             return (retc, pout, perr)
 
         p.value = value
@@ -255,8 +345,8 @@ class BigBang():
             Returns True on success and False on failure
         """
         if 'root' not in self.connection_handles[node]:
-            self.logger.error("ssh connection to 'root' of %s is not present" \
-                    % node)
+            self.logger.error("ssh connection to 'root' of %s is not present" %
+                              node)
             return False
         conn = self.get_connection(node, 'root')
         if conn == -1:
@@ -268,8 +358,8 @@ class BigBang():
             conn.close()
             return True
         except KeyError:
-            self.logger.debug("group %s does not exist in %s. Creating now" \
-                    % (group, node))
+            self.logger.debug("group %s does not exist in %s. Creating now" %
+                              (group, node))
             conn.close()
         ret = self.run(node, "groupadd %s" % group)
         if ret[0] != 0:
@@ -290,21 +380,21 @@ class BigBang():
             dict of connection_handles
         """
         if 'root' not in self.connection_handles[node]:
-            self.logger.error("ssh connection to 'root' of %s is not present" \
-                    % node)
+            self.logger.error("ssh connection to 'root' of %s is not present" %
+                              node)
             return False
         conn = self.get_connection(node, 'root')
         if conn == -1:
-            self.logger.error("Unable to get connection to 'root' of node %s" \
-                    % node)
+            self.logger.error("Unable to get connection to 'root' of node %s" %
+                              node)
             return False
         try:
             conn.modules.pwd.getpwnam(user)
             self.logger.debug("User %s already exist in %s" % (user, node))
             return True
         except KeyError:
-            self.logger.debug("User %s doesn't exist in %s. Creating now" \
-                    % (user, node))
+            self.logger.debug("User %s doesn't exist in %s. Creating now" %
+                              (user, node))
         grp_add_cmd = ''
         if group != '':
             ret = self.add_group(node, group)
@@ -314,9 +404,10 @@ class BigBang():
         else:
             group = user
             grp_add_cmd = '-U'
-        ret = self.run(node, "useradd -m %s -p $(perl -e'print " \
-                             "crypt(%s, \"salt\")') %s" \
-                             % (grp_add_cmd, password, user), user='root')
+
+        ret = self.run(node, "useradd -m %s -p $(perl -e'print "
+                       "crypt(%s, \"salt\")') %s" %
+                       (grp_add_cmd, password, user), user='root')
         if ret[0] != 0:
             self.logger.error("Unable to add the user %s to %s" % (user, node))
             return False
@@ -329,11 +420,11 @@ class BigBang():
                     rfh.write(line)
             ruid = conn.modules.pwd.getpwnam(user).pw_uid
             rgid = conn.modules.grp.getgrnam(group).gr_gid
-            conn.modules.os.chown("/home/%s/.ssh/authorized_keys" % \
-                    user, ruid, rgid)
+            conn.modules.os.chown("/home/%s/.ssh/authorized_keys" %
+                                  user, ruid, rgid)
         except:
-            self.logger.error("Unable to write the rsa pub file to %s@%s" \
-                    % (user, node))
+            self.logger.error("Unable to write the rsa pub file to %s@%s" %
+                              (user, node))
             return False
         rfh.close()
         conn.close()
@@ -349,8 +440,8 @@ class BigBang():
         """
         for node in self.connection_handles.keys():
             for user in self.connection_handles[node].keys():
-                self.logger.debug("Closing all connection to %s@%s" \
-                        % (user, node))
+                self.logger.debug("Closing all connection to %s@%s" %
+                                  (user, node))
                 self.connection_handles[node][user][2].close()
                 self.connection_handles[node][user][1].close()
                 self.connection_handles[node][user][0].close()

--- a/tests_d/example/test_connections.py
+++ b/tests_d/example/test_connections.py
@@ -1,0 +1,61 @@
+#  This file is part of DiSTAF
+#  Copyright (C) 2015-2016  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from distaf.util import tc, testcase
+from distaf.distaf_base_class import DistafTestClass
+
+
+@testcase("exercise_remote_commands")
+class ExerciseRemoteConnections(DistafTestClass):
+    """Run some commands against remote servers to
+    test connectivity and speed.
+
+    To test speed differences, set combinations of...
+        use_ssh : True|False
+        use_controlpersist : True|False    # requires use_ssh : True
+        skip_log_inject : True|False
+
+    Run with...
+        time python main.py -d example -t exercise_remote_commands
+    """
+    def setup(self):
+        return True
+
+    def run(self):
+        retstat = 0
+        for i in range(1, 10):
+            for node in tc.all_nodes:
+                tc.logger.info("Connection %s %i" % (node, i))
+                rcode, _, _ = tc.run(node, "ls -dl /etc")
+                if rcode != 0:
+                    retstat = retstat | rcode
+
+                rcode, _, _ = tc.run(node, "ls -dl /etc >&2")
+                if rcode != 0:
+                    retstat = retstat | rcode
+
+        if retstat == 0:
+            return True
+
+        return False
+
+    def cleanup(self):
+        return True
+
+    def teardown(self):
+        return True

--- a/tests_d/example/test_passfail.py
+++ b/tests_d/example/test_passfail.py
@@ -37,9 +37,6 @@ class GoingToPass(DistafTestClass):
       - tag2
       - tag3
     """
-    def setup(self):
-        return True
-
     def run(self):
         config = self.config_data
         tc.logger.info("Testing connection and command exec")
@@ -73,9 +70,6 @@ class GoingToFail(DistafTestClass):
       - tag2
       - tag3
     """
-    def setup(self):
-        return True
-
     def run(self):
         config = self.config_data
         tc.logger.info("Testing fail output")

--- a/tests_d/example/test_stdout_stderr.py
+++ b/tests_d/example/test_stdout_stderr.py
@@ -1,0 +1,64 @@
+#  This file is part of DiSTAF
+#  Copyright (C) 2015-2016  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from distaf.util import tc, testcase
+from distaf.distaf_base_class import DistafTestClass
+
+
+@testcase("text_to_stdout_stderr")
+class TextToStdoutStderr(DistafTestClass):
+    """Run some commands against remote servers to
+    test sending data to stdout and stderr.
+
+    To test speed differences, set combinations of...
+        use_ssh : True|False
+        use_controlpersist : True|False    # requires use_ssh : True
+        skip_log_inject : True|False
+
+    Run with...
+        time python main.py -d example -t text_to_stdout_stderr
+    """
+    def setup(self):
+        return True
+
+    def run(self):
+        retstat = 0
+        tc.logger.info("Send load of output to stdout")
+        for node in tc.all_nodes:
+            command = "for i in $(seq 1 100); do ls -Rail /etc; done"
+            rcode, _, _ = tc.run(node, command)
+            if rcode != 0:
+                retstat = retstat | rcode
+
+        tc.logger.info("Send load of output to stderr")
+        for node in tc.all_nodes:
+            command = "for i in $(seq 1 100); do ls -Rail /etc >&2; done"
+            rcode, _, _ = tc.run(node, command)
+            if rcode != 0:
+                retstat = retstat | rcode
+
+        if retstat == 0:
+            return True
+
+        return False
+
+    def cleanup(self):
+        return True
+
+    def teardown(self):
+        return True


### PR DESCRIPTION
Using straight ssh for shell commands cuts the total test time down
versus using rpyc connection for all connections.
rpyc connections connect as needed via refresh_connection
or user can "prime" rpyc connections using establish_connection in setup().

* client_rpyc	- added SshMachine connection in run()
		- pep8 cleanup
* util.py	- logic to use ssh instead of rpyc for log mod commands
		- skip_log_inject when set in global config
* test_connections.py	- run a lot of commands against connections
* test_passfail.py	- removed extraneous setup methods
* test_stdout_stderr	- send data across stdout/stderr

Signed-off-by: Jonathan Holloway <loadtheaccumulator@gmail.com>