### PR TITLE
Add multiple config file option at command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ How to run
 
  - To create junit output in directory /tmp/test_results: `python main.py -j /tmp/test_results`
 
+ - To specify one or more yaml formatted config files at the command-line:
+    - single config file
+    ```python main.py -c config_filename```
+    - multiple config files
+    ```python main.py -c "config_filename1 config_filename2"```
+    - multiple config files with bash filename expansion
+    ```python main.py -c "`ls config_*`"```
+    - multiple config files listed in a single file
+    ```python main.py -c "`cat configlist.txt`"```
+
 How to write tests
 ====================
 

--- a/distaf/config_parser.py
+++ b/distaf/config_parser.py
@@ -19,13 +19,15 @@
 import yaml
 
 
-def get_global_config(config_file):
+def get_global_config(config_files):
     """
         Gets all the config data from the distaf_config.yml file
 
         Returns the parsed output of config in a dictionary format
     """
-    configs = yaml.load(open(config_file, 'r'))
+    configs = {}
+    for config_file in config_files:
+        configs.update(yaml.load(open(config_file, 'r')))
     for vol in configs['volumes']:
         for node in configs['volumes'][vol]['nodes']:
             if node not in configs['nodes']:
@@ -34,6 +36,7 @@ def get_global_config(config_file):
             for node in configs['volumes'][vol]['peers']:
                 if node not in configs['peers']:
                     configs['nodes'][node] = {}
+
     return configs
 
 

--- a/distaf/util.py
+++ b/distaf/util.py
@@ -30,12 +30,13 @@ global_mode = None
 tc = None
 
 
-def distaf_init(config_file="config.yml"):
+def distaf_init(config_file_string="config.yml"):
     """
         The distaf init function which calls the  BigBang
     """
+    config_files = config_file_string.split()
     global globl_configs, global_mode, tc
-    globl_configs = get_global_config(config_file)
+    globl_configs = get_global_config(config_files)
     global_mode = globl_configs['global_mode']
     tc = BigBang(globl_configs)
     return globl_configs


### PR DESCRIPTION
Adds the ability to pass a space (or newline) delimited list of files
	using the -c option at the command line.

* config_parser.py: loop through a list of config files and concat
* util.py: split the config string into a list of filenames
* README: updated readme with examples

Signed-off-by: Jonathan Holloway <loadtheaccumulator@gmail.com>