### PR TITLE
Add straight ssh for remote shell commands and examples to test

### DIFF
--- a/tests_d/examples/test_async.py
+++ b/tests_d/examples/test_async.py
@@ -1,0 +1,58 @@
+#  This file is part of DiSTAF
+#  Copyright (C) 2015-2016  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from distaf.util import tc, testcase
+from distaf.distaf_base_class import DistafTestClass
+
+
+@testcase("run_async")
+class RunAsync(DistafTestClass):
+    """Run a command against all servers via run_async()
+
+    Run with...
+        time python main.py -d examples -t run_async
+    """
+    def setup(self):
+        return True
+
+    def run(self):
+        retstat = 0
+        tc.logger.info("Run command on all servers via run_async()")
+
+        rasyncs = {}
+        results = {}
+        command = 'ls -ail; hostname'
+        for node in tc.nodes:
+            rasyncs[node] = tc.run_async(node, command)
+            if not rasyncs[node]:
+                retstat = retstat | rcode
+
+        for node, proc in rasyncs.items():
+            rcode, rout, rerr = proc.value()
+            retstat = retstat | rcode
+
+        if retstat == 0:
+            return True
+
+        return False
+
+    def cleanup(self):
+        return True
+
+    def teardown(self):
+        return True

--- a/tests_d/examples/test_connections.py
+++ b/tests_d/examples/test_connections.py
@@ -1,0 +1,63 @@
+#  This file is part of DiSTAF
+#  Copyright (C) 2015-2016  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from distaf.util import tc, testcase
+from distaf.distaf_base_class import DistafTestClass
+
+
+@testcase("exercise_remote_commands")
+class ExerciseRemoteConnections(DistafTestClass):
+    """Run some commands against remote servers to
+    test connectivity and speed.
+
+    To test speed differences, set combinations of...
+        connection_engine : ssh_controlpersist (default)
+        connection_engine : rpyc
+        connection_engine : ssh
+
+        skip_log_inject : True|False
+
+    Run with...
+        time python main.py -d examples -t exercise_remote_commands
+    """
+    def setup(self):
+        return True
+
+    def run(self):
+        retstat = 0
+        for i in range(1, 10):
+            for node in tc.all_nodes:
+                tc.logger.info("Connection %s %i" % (node, i))
+                rcode, _, _ = tc.run(node, "ls -dl /etc")
+                if rcode != 0:
+                    retstat = retstat | rcode
+
+                rcode, _, _ = tc.run(node, "ls -dl /etc >&2")
+                if rcode != 0:
+                    retstat = retstat | rcode
+
+        if retstat == 0:
+            return True
+
+        return False
+
+    def cleanup(self):
+        return True
+
+    def teardown(self):
+        return True

--- a/tests_d/examples/test_passfail.py
+++ b/tests_d/examples/test_passfail.py
@@ -37,9 +37,6 @@ class GoingToPass(GlusterBaseClass):
       - tag2
       - tag3
     """
-    def setup(self):
-        return True
-
     def run(self):
         config = self.config_data
         tc.logger.info("Testing connection and command exec")
@@ -73,9 +70,6 @@ class GoingToFail(GlusterBaseClass):
       - tag2
       - tag3
     """
-    def setup(self):
-        return True
-
     def run(self):
         config = self.config_data
         tc.logger.info("Testing fail output")

--- a/tests_d/examples/test_stdout_stderr.py
+++ b/tests_d/examples/test_stdout_stderr.py
@@ -1,0 +1,78 @@
+#  This file is part of DiSTAF
+#  Copyright (C) 2015-2016  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from distaf.util import tc, testcase
+from distaf.distaf_base_class import DistafTestClass
+
+
+@testcase("text_to_stdout_stderr")
+class TextToStdoutStderr(DistafTestClass):
+    """Run some commands against remote servers to
+    test sending data to stdout and stderr.
+    Set to 1000, dump approx. 150M of text to output
+
+    To test speed differences, set combinations of...
+        connection_engine : ssh_controlpersist (default)
+        connection_engine : rpyc
+        connection_engine : ssh
+
+        skip_log_inject : True|False
+
+    Run with...
+        time python main.py -d examples -t text_to_stdout_stderr
+    """
+    def setup(self):
+        return True
+
+    def run(self):
+        retstat = 0
+        tc.logger.info("Send load of text output to stdout")
+        command = '''ls -Rail /etc > /tmp/railetc
+            for i in $(seq 1 1000)
+            do
+                cat /tmp/railetc
+            done
+            echo "Complete"
+            '''
+        rcode, _, _ = tc.run(tc.nodes[0], command)
+        if rcode != 0:
+            retstat = retstat | rcode
+
+        tc.logger.info("Send load of text output to stderr")
+        command = '''ls -Rail /etc > /tmp/railetc
+            for i in $(seq 1 1000)
+            do
+                cat /tmp/railetc >&2
+            done
+            echo "Complete" >&2
+            '''
+        rcode, _, _ = tc.run(tc.nodes[0], command)
+        if rcode != 0:
+            retstat = retstat | rcode
+
+        if retstat == 0:
+            return True
+
+        return False
+
+    def cleanup(self):
+        command = "rm -f /tmp/railetc"
+        return True
+
+    def teardown(self):
+        return True


### PR DESCRIPTION
Using straight ssh for shell commands cuts the total test time down
versus using rpyc connection for all connections.
rpyc connections connect as needed via refresh_connection
or user can "prime" rpyc connections using establish_connection in setup().

* client_rpyc   - added SshMachine connection in run() and run_async()
                      - pep8 cleanup
* util.py       - skip_log_inject when set in global config
* test_connections.py   - run a lot of commands against connections
* test_passfail.py      - removed extraneous setup methods
* test_stdout_stderr    - send data across stdout/stderr
* test_async            - test commands via run_async()

Signed-off-by: Jonathan Holloway <loadtheaccumulator@gmail.com>